### PR TITLE
Request to Merge

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java
@@ -51,10 +51,15 @@ public final class JsonTreeReader extends JsonReader {
       };
   private static final Object SENTINEL_CLOSED = new Object();
 
-  /*
-   * The nesting stack. Using a manual array rather than an ArrayList saves 20%.
-   */
+  /** The nesting stack. Using a manual array rather than an ArrayList saves 20%. */
   private Object[] stack = new Object[32];
+
+  /**
+   * The used size of {@link #stack}; the value at {@code stackSize - 1} is the value last placed on
+   * the stack. {@code stackSize} might differ from the nesting depth, because the stack also
+   * contains temporary additional objects, for example for a JsonArray it contains the JsonArray
+   * object as well as the corresponding iterator.
+   */
   private int stackSize = 0;
 
   /*

--- a/gson/src/test/java/com/google/gson/JsonParserTest.java
+++ b/gson/src/test/java/com/google/gson/JsonParserTest.java
@@ -94,23 +94,17 @@ public class JsonParserTest {
     assertThat(array.get(2).getAsString()).isEqualTo("stringValue");
   }
 
-  private static String repeat(String s, int times) {
-    StringBuilder stringBuilder = new StringBuilder(s.length() * times);
-    for (int i = 0; i < times; i++) {
-      stringBuilder.append(s);
-    }
-    return stringBuilder.toString();
-  }
-
   /** Deeply nested JSON arrays should not cause {@link StackOverflowError} */
   @Test
   public void testParseDeeplyNestedArrays() throws IOException {
     int times = 10000;
     // [[[ ... ]]]
-    String json = repeat("[", times) + repeat("]", times);
+    String json = "[".repeat(times) + "]".repeat(times);
+    JsonReader jsonReader = new JsonReader(new StringReader(json));
+    jsonReader.setNestingLimit(Integer.MAX_VALUE);
 
     int actualTimes = 0;
-    JsonArray current = JsonParser.parseString(json).getAsJsonArray();
+    JsonArray current = JsonParser.parseReader(jsonReader).getAsJsonArray();
     while (true) {
       actualTimes++;
       if (current.isEmpty()) {
@@ -127,10 +121,12 @@ public class JsonParserTest {
   public void testParseDeeplyNestedObjects() throws IOException {
     int times = 10000;
     // {"a":{"a": ... {"a":null} ... }}
-    String json = repeat("{\"a\":", times) + "null" + repeat("}", times);
+    String json = "{\"a\":".repeat(times) + "null" + "}".repeat(times);
+    JsonReader jsonReader = new JsonReader(new StringReader(json));
+    jsonReader.setNestingLimit(Integer.MAX_VALUE);
 
     int actualTimes = 0;
-    JsonObject current = JsonParser.parseString(json).getAsJsonObject();
+    JsonObject current = JsonParser.parseReader(jsonReader).getAsJsonObject();
     while (true) {
       assertThat(current.size()).isEqualTo(1);
       actualTimes++;

--- a/gson/src/test/java/com/google/gson/internal/bind/JsonTreeReaderTest.java
+++ b/gson/src/test/java/com/google/gson/internal/bind/JsonTreeReaderTest.java
@@ -138,6 +138,51 @@ public class JsonTreeReaderTest {
   }
 
   /**
+   * {@link JsonTreeReader} ignores nesting limit because:
+   *
+   * <ul>
+   *   <li>It is an internal class and often created implicitly without the user having access to it
+   *       (as {@link JsonReader}), so they cannot easily adjust the limit
+   *   <li>{@link JsonTreeReader} may be created based on an existing {@link JsonReader}; in that
+   *       case it would be necessary to propagate settings to account for a custom nesting limit,
+   *       see also related https://github.com/google/gson/pull/2151
+   *   <li>Nesting limit as protection against {@link StackOverflowError} is not that relevant for
+   *       {@link JsonTreeReader} because a deeply nested {@link JsonElement} tree would first have
+   *       to be constructed; and if it is constructed from a regular {@link JsonReader}, then its
+   *       nesting limit would already apply
+   * </ul>
+   */
+  @Test
+  public void testNestingLimitIgnored() throws IOException {
+    int limit = 10;
+    JsonArray json = new JsonArray();
+    JsonArray current = json;
+    // This adds additional `limit` nested arrays, so in total there are `limit + 1` arrays
+    for (int i = 0; i < limit; i++) {
+      JsonArray nested = new JsonArray();
+      current.add(nested);
+      current = nested;
+    }
+
+    JsonTreeReader reader = new JsonTreeReader(json);
+    reader.setNestingLimit(limit);
+    assertThat(reader.getNestingLimit()).isEqualTo(limit);
+
+    for (int i = 0; i < limit; i++) {
+      reader.beginArray();
+    }
+    // Does not throw exception; limit is ignored
+    reader.beginArray();
+
+    reader.endArray();
+    for (int i = 0; i < limit; i++) {
+      reader.endArray();
+    }
+    assertThat(reader.peek()).isEqualTo(JsonToken.END_DOCUMENT);
+    reader.close();
+  }
+
+  /**
    * {@link JsonTreeReader} effectively replaces the complete reading logic of {@link JsonReader} to
    * read from a {@link JsonElement} instead of a {@link Reader}. Therefore all relevant methods of
    * {@code JsonReader} must be overridden.
@@ -149,7 +194,9 @@ public class JsonTreeReaderTest {
             "setLenient(boolean)",
             "isLenient()",
             "setStrictness(com.google.gson.Strictness)",
-            "getStrictness()");
+            "getStrictness()",
+            "setNestingLimit(int)",
+            "getNestingLimit()");
     MoreAsserts.assertOverridesMethods(JsonReader.class, JsonTreeReader.class, ignoredMethods);
   }
 }


### PR DESCRIPTION
### **User description**
> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **PR Type**
enhancement, tests


___

### **Description**
- Introduced a configurable nesting limit in `JsonReader` to prevent `StackOverflowError` with deeply nested JSON.
- Added methods to set and get the nesting limit, with a default value of 255.
- Updated multiple test classes to verify the new nesting limit functionality and ensure proper error handling.
- Enhanced documentation and comments to clarify the purpose and usage of the nesting stack and limits.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JsonReader.java</strong><dd><code>Add nesting limit configuration to JsonReader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gson/src/main/java/com/google/gson/stream/JsonReader.java

<li>Introduced a default nesting limit for JSON reading.<br> <li> Added methods to set and get the nesting limit.<br> <li> Enhanced error handling for exceeding nesting limits.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/gson/pull/4/files#diff-0ddecddf64de180e8e9bc664a064e57ee4475426b3027089cf940ca48e6f8b19">+50/-4</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JsonTreeReader.java</strong><dd><code>Document nesting stack and stackSize in JsonTreeReader</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gson/src/main/java/com/google/gson/internal/bind/JsonTreeReader.java

<li>Added documentation explaining the nesting stack.<br> <li> Clarified the role of stackSize in the nesting process.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/gson/pull/4/files#diff-2002b8d1e823c7469f9ac843c82da7359c22c37d6c7932a2bf551b7f7b22ce72">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JsonParserTest.java</strong><dd><code>Update JsonParserTest for nesting limit and String.repeat</code></dd></summary>
<hr>

gson/src/test/java/com/google/gson/JsonParserTest.java

<li>Updated tests to use new nesting limit feature.<br> <li> Replaced manual string repetition with String.repeat.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/gson/pull/4/files#diff-0e0ab394f9a8e2084a4de69ad1408d07389add064a2270dcc464596799fc83be">+8/-12</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ObjectTypeAdapterTest.java</strong><dd><code>Update ObjectTypeAdapterTest for nesting limit and String.repeat</code></dd></summary>
<hr>

gson/src/test/java/com/google/gson/ObjectTypeAdapterTest.java

<li>Updated tests to use new nesting limit feature.<br> <li> Replaced manual string repetition with String.repeat.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/gson/pull/4/files#diff-546b64abdf6a6d2cf9b384e201ede9188c5d1f366ec5a9c8c01c8801cdbeb780">+10/-12</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ObjectTest.java</strong><dd><code>Add tests for deeply nested JSON handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gson/src/test/java/com/google/gson/functional/ObjectTest.java

<li>Added test for deeply nested JSON structures.<br> <li> Verified behavior with default nesting limit.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/gson/pull/4/files#diff-91b3726c4adfbdf06ceded79722e0dd0853553453002aec1b3be2c3597a14ed3">+27/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>JsonTreeReaderTest.java</strong><dd><code>Test and document nesting limit behavior in JsonTreeReader</code></dd></summary>
<hr>

gson/src/test/java/com/google/gson/internal/bind/JsonTreeReaderTest.java

<li>Added test to verify that nesting limit is ignored.<br> <li> Documented rationale for ignoring nesting limit.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/gson/pull/4/files#diff-73a3d6dd6da47679f0dc3b30b6e8a33cdaf6cf2d379d43ef8d071b8fecf206e6">+48/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>JsonReaderTest.java</strong><dd><code>Add tests for JsonReader nesting limit functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gson/src/test/java/com/google/gson/stream/JsonReaderTest.java

<li>Added tests for default and custom nesting limits.<br> <li> Verified exception handling for invalid nesting limits.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/gson/pull/4/files#diff-b39ee1ea93145228e7c0562a08be13f91db2a403782e16cda75f9dd4986dedf9">+77/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information