### PR TITLE
Request to Merge

### DIFF
--- a/gson/src/main/java/com/google/gson/JsonPrimitive.java
+++ b/gson/src/main/java/com/google/gson/JsonPrimitive.java
@@ -293,11 +293,16 @@ public final class JsonPrimitive extends JsonElement {
           : this.getAsNumber().longValue() == other.getAsNumber().longValue();
     }
     if (value instanceof Number && other.value instanceof Number) {
-      double a = getAsNumber().doubleValue();
-      // Java standard types other than double return true for two NaN. So, need
-      // special handling for double.
-      double b = other.getAsNumber().doubleValue();
-      return a == b || (Double.isNaN(a) && Double.isNaN(b));
+      if (value instanceof BigDecimal && other.value instanceof BigDecimal) {
+        // Uses compareTo to ignore scale of values, e.g. `0` and `0.00` should be considered equal
+        return this.getAsBigDecimal().compareTo(other.getAsBigDecimal()) == 0;
+      }
+
+      double thisAsDouble = this.getAsDouble();
+      double otherAsDouble = other.getAsDouble();
+      // Don't use Double.compare(double, double) because that considers -0.0 and +0.0 not equal
+      return (thisAsDouble == otherAsDouble)
+          || (Double.isNaN(thisAsDouble) && Double.isNaN(otherAsDouble));
     }
     return value.equals(other.value);
   }

--- a/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
+++ b/gson/src/test/java/com/google/gson/JsonPrimitiveTest.java
@@ -321,4 +321,35 @@ public class JsonPrimitiveTest {
     JsonPrimitive a = new JsonPrimitive("a");
     assertThat(a).isSameInstanceAs(a.deepCopy()); // Primitives are immutable!
   }
+
+  @Test
+  public void testBigDecimalEquals() {
+    JsonPrimitive small = new JsonPrimitive(1.0);
+    JsonPrimitive large = new JsonPrimitive(2.0);
+    assertThat(small.equals(large)).isFalse();
+
+    BigDecimal doubleMax = BigDecimal.valueOf(Double.MAX_VALUE);
+    JsonPrimitive smallBD = new JsonPrimitive(doubleMax.add(new BigDecimal("100.0")));
+    JsonPrimitive largeBD = new JsonPrimitive(doubleMax.add(new BigDecimal("200.0")));
+    assertThat(smallBD.equals(largeBD)).isFalse();
+  }
+
+  @Test
+  public void testBigDecimalEqualsZero() {
+    assertThat(
+            new JsonPrimitive(new BigDecimal("0.0"))
+                .equals(new JsonPrimitive(new BigDecimal("0.00"))))
+        .isTrue();
+
+    assertThat(
+            new JsonPrimitive(new BigDecimal("0.00"))
+                .equals(new JsonPrimitive(Double.valueOf("0.00"))))
+        .isTrue();
+  }
+
+  @Test
+  public void testEqualsDoubleNaNAndBigDecimal() {
+    assertThat(new JsonPrimitive(Double.NaN).equals(new JsonPrimitive(new BigDecimal("1.0"))))
+        .isFalse();
+  }
 }


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Enhanced `JsonPrimitive#equals` method to support `BigDecimal` comparison using `compareTo`, allowing for scale differences.
- Improved handling of `double` values, ensuring correct comparison for `NaN` and zero values.
- Added comprehensive tests to verify `BigDecimal` equality handling, including different scales and interaction with `Double.NaN`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JsonPrimitive.java</strong><dd><code>Enhance `JsonPrimitive#equals` to support `BigDecimal` comparison</code></dd></summary>
<hr>

gson/src/main/java/com/google/gson/JsonPrimitive.java

<li>Added support for <code>BigDecimal</code> comparison in <code>JsonPrimitive#equals</code>.<br> <li> Used <code>compareTo</code> for <code>BigDecimal</code> to ignore scale differences.<br> <li> Improved handling of <code>double</code> values, including <code>NaN</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/gson/pull/6/files#diff-cd5c01639f5077f3e27295694ccdc652312db67e3b561ee6559bf6ffa5d68010">+10/-5</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JsonPrimitiveTest.java</strong><dd><code>Add tests for `BigDecimal` support in `JsonPrimitive#equals`</code></dd></summary>
<hr>

gson/src/test/java/com/google/gson/JsonPrimitiveTest.java

<li>Added tests for <code>BigDecimal</code> equality in <code>JsonPrimitive</code>.<br> <li> Tested equality for different scales of <code>BigDecimal</code>.<br> <li> Verified behavior with <code>Double.NaN</code> and <code>BigDecimal</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/gson/pull/6/files#diff-8a9139e060e1a656211cc15ea8158547de360fdad9b99e7389be8197a53c3127">+31/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information